### PR TITLE
Add support for adding a title to the blog excerpt image

### DIFF
--- a/_includes/post/excerpt_image.html
+++ b/_includes/post/excerpt_image.html
@@ -1,0 +1,12 @@
+{% assign excerpt_image = post.excerpt_image %}
+{% if excerpt_image %}
+    {% if excerpt_image.url %}
+        {% if excerpt_image.title %}
+            <img src="{{ excerpt_image.url }}" class="excerpt" title="{{ excerpt_image.title %}}" />
+        {% else %}
+            <img src="{{ excerpt_image.url }}" class="excerpt" />
+        {% endif %}
+    {% else %}
+        <img src="{{ excerpt_image }}" class="excerpt" />
+    {% endif %}
+{% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -47,9 +47,7 @@ layout: default
                 <div class="post-content" itemprop="articleBody">
                   {% if site.show_excerpts %}
                     <div class="excerpt">
-                      {% if post.excerpt_image %}
-                      <img src="{{ post.excerpt_image }}" class="excerpt" />
-                      {% endif %}
+                      {% include post/excerpt_image.html %}
                       {{ post.excerpt }}
                       <a href="{{ post.url | relative_url }}" class="read-more">Read More</a>
                     </div>

--- a/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
+++ b/_posts/2016-05-20-this-post-demonstrates-post-content-styles.md
@@ -6,6 +6,7 @@ meta: "Springfield"
 author:
   avatar: /assets/img/unknown-avatar.png
   name: The Author
+excerpt_image: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce bibendum neque eget nunc mattis eu sollicitudin enim tincidunt. Vestibulum lacus tortor, ultricies id dignissim ac, bibendum in velit.

--- a/_posts/2016-05-20-welcome-to-jekyll.md
+++ b/_posts/2016-05-20-welcome-to-jekyll.md
@@ -4,7 +4,9 @@ tags: [sample, intro]
 author:
   avatar: https://2.gravatar.com/avatar/cdf546b601bf29a7eb4ca777544d11cd?s=160
   name: haacked
-excerpt_image: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
+excerpt_image:
+  url: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
+  title: "The title of the excerpt image"
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 


### PR DESCRIPTION
The titles are where we add attribution to images we use. This change is backwards compatible.

Old style (_still works_)
```
excerpt_image: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
```

New style (_still works_)
```
excerpt_image:
    url: https://user-images.githubusercontent.com/19977/107439587-26731d00-6ae7-11eb-925c-0f50f09f2969.png
    title: "Abbot Robot created by Jason Costello"
```